### PR TITLE
Port to Microsoft Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 kilo: kilo.c
-	$(CC) kilo.c -o kilo -Wall -Wextra -pedantic -std=c99
+	$(CC) kilo.c -o kilo -Wall -Wextra -pedantic -std=c11
 
 all: kilo
 

--- a/Makefile.win32
+++ b/Makefile.win32
@@ -1,0 +1,10 @@
+# Makefile for Windows NMAKE. Use command:
+# nmake /f Makefile.win32
+#
+kilo: kilo.c kilo_win32.c
+	$(CC) kilo.c kilo_win32.c /o kilo /Wall
+
+all: kilo
+
+clean:
+	del kilo

--- a/Makefile.win32
+++ b/Makefile.win32
@@ -2,7 +2,7 @@
 # nmake /f Makefile.win32
 #
 kilo: kilo.c kilo_win32.c
-	$(CC) kilo.c kilo_win32.c /o kilo /Wall
+	$(CC) kilo.c kilo_win32.c /o kilo /Wall /std:c11
 
 all: kilo
 

--- a/README.md
+++ b/README.md
@@ -2,3 +2,20 @@
 
 Implementation of a simple text editor in C, following the steps in the
 [Build Your Own Text Editor](https://viewsourcecode.org/snaptoken/kilo/) tutorial.
+
+Completed all steps from 1 to 184.
+
+Also ported to Microsoft Windows, adding `#ifdef _WIN32`
+to replace UNIX-specific system
+calls with Windows API `GetConsoleMode`,
+`SetConsoleMode`,
+`GetConsoleScreenBufferInfo`,
+`ReadConsole` and `WriteConsole` calls.
+
+To compile on Linux use:
+
+    make -f Makefile
+
+To compile on Microsoft Windows use:
+
+    nmake /f Makefile.win32

--- a/kilo.c
+++ b/kilo.c
@@ -254,7 +254,11 @@ readKeypress(void)
 		return -1;
 	}
 #else
-	if (read(STDIN_FILENO, &c, 1) != 1)
+	int nread;
+	while ((nread = read(STDIN_FILENO, &c, 1)) == 0)
+	{
+	}
+	if (nread < 0)
 	{
 		return -1;
 	}

--- a/kilo.c
+++ b/kilo.c
@@ -968,7 +968,7 @@ editorSave(void)
 
 	if (E.filename == NULL)
 	{
-		E.filename = editorPrompt("Save as: %s (ESC to cancel)", NULL);
+		E.filename = editorPrompt("Save as: %s (ESC or Ctrl-Q to cancel)", NULL);
 		if (E.filename == NULL)
 		{
 			editorSetStatusMessage("Save aborted");
@@ -1086,7 +1086,7 @@ editorFind(void)
 	int saved_coloff = E.coloff;
 	int saved_rowoff = E.rowoff;
 
-	char *query = editorPrompt("Search: %s (Use ESC/Arrows/Enter)", editorFindCallback);
+	char *query = editorPrompt("Search: %s (Use ESC/Ctrl-Q/Arrows/Enter)", editorFindCallback);
 	if (query)
 	{
 		free(query);
@@ -1154,7 +1154,7 @@ editorPrompt(char *prompt, void (*callback)(char *, int))
 				buf[--buflen] = '\0';
 			}
 		}
-		else if (c == '\x1b')
+		else if (c == '\x1b' || c == CTRL_KEY('q'))
 		{
 				editorSetStatusMessage("");
 				if (callback)

--- a/kilo.c
+++ b/kilo.c
@@ -1583,7 +1583,6 @@ initEditor(void)
 	E.statusmsg[0] = '\0';
 	E.statusmsg_time = 0;
 	E.syntax = NULL;
-	memset(&E.orig_termios, 0, sizeof(E.orig_termios));
 
 	if (getWindowSize(&E.screenrows, &E.screencols) == -1)
 	{

--- a/kilo.c
+++ b/kilo.c
@@ -329,6 +329,17 @@ getCurrentPosition(int *rows, int *cols)
 int
 getWindowSize(int *rows, int *cols)
 {
+#ifdef _WIN32
+	CONSOLE_SCREEN_BUFFER_INFO csbi;
+
+	if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi) == FALSE)
+	{
+		return -1;
+	}
+	*cols = csbi.srWindow.Right - csbi.srWindow.Left + 1;
+	*rows = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
+	return 0;
+#else
 	struct winsize ws;
 
 	if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) == -1 || ws.ws_col == 0)
@@ -345,6 +356,7 @@ getWindowSize(int *rows, int *cols)
 		*rows = ws.ws_row;
 		return 0;
 	}
+#endif
 }
 
 /*** syntax highlighting ***/

--- a/kilo.c
+++ b/kilo.c
@@ -911,7 +911,7 @@ editorDelChar(void)
 /*** file i/o ***/
 
 char *
-editorRowsToString(int *buflen)
+editorRowsToString(size_t *buflen)
 {
 	int totlen = 0;
 	int j;
@@ -982,7 +982,7 @@ editorSave(void)
 		is_new_file = 1;
 	}
 
-	int len;
+	size_t len;
 	char *buf = editorRowsToString(&len);
 
 	FILE *fp = fopen(E.filename, (is_new_file ? "wx" : "w"));

--- a/kilo.c
+++ b/kilo.c
@@ -992,7 +992,7 @@ editorSave(void)
 			editorSetStatusMessage("%d bytes written to disk", len);
 			return;
 		}
-		close(fp);
+		fclose(fp);
 	}
 	editorSetStatusMessage("Cannot save! I/O error: %s", strerror(errno));
 	free(buf);

--- a/kilo.c
+++ b/kilo.c
@@ -4,10 +4,19 @@
 #define _BSD_SOURCE
 #define _GNU_SOURCE
 
+#ifdef _WIN32
+#include "kilo_win32.h"
+#else
 #include <sys/ioctl.h>
+#endif
+
 #include <sys/types.h>
+
+#ifndef _WIN32
 #include <termios.h>
 #include <unistd.h>
+#endif
+
 #include <errno.h>
 #include <ctype.h>
 #include <stdio.h>

--- a/kilo_win32.c
+++ b/kilo_win32.c
@@ -9,5 +9,45 @@ ftruncate(int fd, int len)
 int
 getline(char **line, size_t *linecap, FILE *fp)
 {
-	return 0;
+	if (*line == NULL)
+	{
+		*linecap = 0;
+	}
+
+	int len = 0;
+	int c = fgetc(fp);
+	if (c == EOF)
+	{
+		return -1;
+	}
+
+	while (c != EOF)
+	{
+		if (len + 1 >= *linecap)
+		{
+			*linecap += 256;
+			*line = realloc(*line, *linecap);
+			if (*line == NULL)
+			{
+				return -1;
+			}
+			memset((*line) + len, '\0', (*linecap) - len);
+		}
+		(*line)[len] = c;
+		len++;
+		if (c == '\n')
+		{
+			break;
+		}
+
+		int next_c = fgetc(fp);
+		if (c == '\r' && next_c == '\n')
+		{
+			(*line)[len] = next_c;
+			len++;
+			break;
+		}
+		c = next_c;
+	}
+	return len;
 }

--- a/kilo_win32.c
+++ b/kilo_win32.c
@@ -11,15 +11,3 @@ getline(char **line, size_t *linecap, FILE *fp)
 {
 	return 0;
 }
-
-int
-tcgetattr(int fd, struct termios *termios)
-{
-	return 0;
-}
-
-int
-tcsetattr(int fd, int flags, struct termios *termios)
-{
-	return 0;
-}

--- a/kilo_win32.c
+++ b/kilo_win32.c
@@ -13,12 +13,6 @@ getline(char **line, size_t *linecap, FILE *fp)
 }
 
 int
-ioctl(int fd, int flags, struct winsize *ws)
-{
-	return 0;
-}
-
-int
 tcgetattr(int fd, struct termios *termios)
 {
 	return 0;

--- a/kilo_win32.c
+++ b/kilo_win32.c
@@ -1,12 +1,6 @@
 #include "kilo_win32.h"
 
 int
-ftruncate(int fd, int len)
-{
-	return 0;
-}
-
-int
 getline(char **line, size_t *linecap, FILE *fp)
 {
 	if (*line == NULL)

--- a/kilo_win32.c
+++ b/kilo_win32.c
@@ -1,0 +1,31 @@
+#include "kilo_win32.h"
+
+int
+ftruncate(int fd, int len)
+{
+	return 0;
+}
+
+int
+getline(char **line, size_t *linecap, FILE *fp)
+{
+	return 0;
+}
+
+int
+ioctl(int fd, int flags, struct winsize *ws)
+{
+	return 0;
+}
+
+int
+tcgetattr(int fd, struct termios *termios)
+{
+	return 0;
+}
+
+int
+tcsetattr(int fd, int flags, struct termios *termios)
+{
+	return 0;
+}

--- a/kilo_win32.c
+++ b/kilo_win32.c
@@ -17,6 +17,10 @@ getline(char **line, size_t *linecap, FILE *fp)
 
 	while (c != EOF)
 	{
+		/*
+		 * Ensure space for `len + 1` chars to handle case of
+		 * adding two chars \r and \n below.
+		 */
 		if (len + 1 >= *linecap)
 		{
 			*linecap += 256;

--- a/kilo_win32.h
+++ b/kilo_win32.h
@@ -6,28 +6,9 @@
 #define STDIN_FILENO 0
 #define STDOUT_FILENO 1
 
-#define TCSAFLUSH 0
-#define BRKINT 0
-#define ICRNL 0
-#define INPCK 0
-#define ISTRIP 0
-#define IXON 0
-#define OPOST 0
-#define CS8 0
-#define ECHO 0
-#define ICANON 0
-#define IEXTEN 0
-#define ISIG 0
-#define VMIN 0
-#define VTIME 0
-
 struct termios
 {
-	int c_cflag;
-	int c_iflag;
-	int c_lflag;
-	int c_oflag;
-	int c_cc[1];
+	DWORD console_mode;
 };
 
 struct winsize
@@ -41,9 +22,5 @@ typedef unsigned int ssize_t;
 int ftruncate(int fd, int len);
 
 int getline(char **line, size_t *linecap, FILE *fp);
-
-int tcgetattr(int fd, struct termios *termios);
-
-int tcsetattr(int fd, int flags, struct termios *termios);
 
 #define TIOCGWINSZ 0

--- a/kilo_win32.h
+++ b/kilo_win32.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <stdio.h>
+#include <Windows.h>
+
+#define STDIN_FILENO 0
+#define STDOUT_FILENO 1
+
+#define TCSAFLUSH 0
+#define BRKINT 0
+#define ICRNL 0
+#define INPCK 0
+#define ISTRIP 0
+#define IXON 0
+#define OPOST 0
+#define CS8 0
+#define ECHO 0
+#define ICANON 0
+#define IEXTEN 0
+#define ISIG 0
+#define VMIN 0
+#define VTIME 0
+
+struct termios
+{
+	int c_cflag;
+	int c_iflag;
+	int c_lflag;
+	int c_oflag;
+	int c_cc[1];
+};
+
+struct winsize
+{
+	int ws_col;
+	int ws_row;
+};
+
+typedef unsigned int ssize_t;
+
+int ftruncate(int fd, int len);
+
+int getline(char **line, size_t *linecap, FILE *fp);
+
+int tcgetattr(int fd, struct termios *termios);
+
+int tcsetattr(int fd, int flags, struct termios *termios);
+
+#define TIOCGWINSZ 0

--- a/kilo_win32.h
+++ b/kilo_win32.h
@@ -3,12 +3,10 @@
 #include <stdio.h>
 #include <Windows.h>
 
-#define STDIN_FILENO 0
-#define STDOUT_FILENO 1
-
 struct termios
 {
-	DWORD console_mode;
+	DWORD console_input_mode; /* from GetConsoleMode() */
+	DWORD console_output_mode; /* from GetConsoleMode() */
 };
 
 struct winsize

--- a/kilo_win32.h
+++ b/kilo_win32.h
@@ -22,5 +22,3 @@ typedef unsigned int ssize_t;
 int ftruncate(int fd, int len);
 
 int getline(char **line, size_t *linecap, FILE *fp);
-
-#define TIOCGWINSZ 0

--- a/kilo_win32.h
+++ b/kilo_win32.h
@@ -17,6 +17,4 @@ struct winsize
 
 typedef unsigned int ssize_t;
 
-int ftruncate(int fd, int len);
-
 int getline(char **line, size_t *linecap, FILE *fp);


### PR DESCRIPTION
Ported completed text editor to MicroSoft Windows, adding `#ifdef _WIN32` code blocks to replace UNIX-specific system calls with Windows API calls.

Added `kilo_win32.c` with Windows-specific functions.

Added `Makefile.win32` for compilation with Windows `nmake`.